### PR TITLE
level finish on song finish

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,14 +1,11 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://assets/player/Player.tscn" type="PackedScene" id=1]
 [ext_resource path="res://test/test-tools/Block.tscn" type="PackedScene" id=2]
 [ext_resource path="res://scenes/Pause.tscn" type="PackedScene" id=3]
-[ext_resource path="res://scripts/obstacles/MovingObstacle.gd" type="Script" id=4]
 [ext_resource path="res://ObstacleHandler.tscn" type="PackedScene" id=5]
 [ext_resource path="res://scripts/LevelLogic.gd" type="Script" id=6]
 [ext_resource path="res://scenes/GameOver.tscn" type="PackedScene" id=7]
-
-[sub_resource type="RectangleShape2D" id=1]
 
 [node name="Node2D" type="Node2D"]
 script = ExtResource( 6 )
@@ -38,13 +35,10 @@ visible = false
 [node name="GameOver" parent="CanvasLayer" instance=ExtResource( 7 )]
 visible = false
 
-[node name="FinishLine" type="KinematicBody2D" parent="."]
-script = ExtResource( 4 )
+[node name="DeathTimer" type="Timer" parent="."]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="FinishLine"]
-shape = SubResource( 1 )
-
-[node name="Timer" type="Timer" parent="."]
-
+[connection signal="finished" from="ObstacleHandler/Song" to="." method="_level_finished"]
 [connection signal="player_collided" from="Player" to="." method="_on_player_collision"]
-[connection signal="timeout" from="Timer" to="." method="_on_Timer_timeout"]
+[connection signal="timeout" from="DeathTimer" to="." method="_on_Timer_timeout"]
+
+[editable path="ObstacleHandler"]

--- a/scripts/LevelLogic.gd
+++ b/scripts/LevelLogic.gd
@@ -5,16 +5,14 @@ extends Node
 func _on_player_collision(other_body: CollisionObject2D):
 	if other_body.get_collision_layer_bit(1):
 		_player_died()
-	elif other_body.get_collision_layer_bit(3):
-		_finish_line_reached()
 
 func _player_died():
 	_stop_all_movement()
 	$CanvasLayer/Pause.disable_pausing()
 	$Player.die()
-	$Timer.start()
+	$DeathTimer.start()
 
-func _finish_line_reached():
+func _level_finished():
 	_stop_all_movement()
 	$CanvasLayer/Pause.disable_pausing()
 	print("LEVEL FINISHED")
@@ -24,11 +22,10 @@ func _stop_all_movement():
 	# TODO: Might need to change how to reference the obstacle manager
 	for node in $ObstacleHandler.obstacles:
 		node.constant_linear_velocity = Vector2.ZERO
-	$FinishLine.constant_linear_velocity = Vector2.ZERO
 
 func _on_Timer_timeout():
 	var time = $ObstacleHandler/Song.get_playback_position()
 	time += AudioServer.get_time_since_last_mix() 
 	time -= AudioServer.get_output_latency()
-	time -= $Timer.wait_time
+	time -= $DeathTimer.wait_time
 	$CanvasLayer/GameOver.game_over(false, time)


### PR DESCRIPTION
Just connected the Song player `finished` signal to Level Logic to trigger the end of the level.

I tested it by changing the song to a short SFX to trigger the signal quickly.

https://user-images.githubusercontent.com/57849620/213567825-8e78fc3c-e155-43bf-b8f5-d17106094b08.mp4

